### PR TITLE
Add GitHub Actions CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,27 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v5
+        with:
+          enable-cache: true
+
+      - name: Install dependencies
+        run: uv sync --frozen --python 3.11
+
+      # 仅运行不依赖外部服务（Milvus/MySQL/Redis/LLM）的单元测试。
+      # 现有 tests/ 全部使用 mock/monkeypatch，可在 CI 中离线运行。
+      - name: Run unit tests
+        run: uv run --frozen --python 3.11 pytest


### PR DESCRIPTION
## What
Adds the repository's first CI workflow: `.github/workflows/ci.yml`.

## Details
- Triggers on `push` and `pull_request` to `main`, runs on `ubuntu-latest`.
- Toolchain: uv project (`pyproject.toml` + `uv.lock`), Python `>=3.11` (pinned to 3.11 in CI for determinism).
- Steps: `astral-sh/setup-uv@v5` (with cache) -> `uv sync --frozen` -> `uv run pytest`.
- Scope: only the existing offline unit tests run. All `tests/` use mock/monkeypatch and do NOT require external services (Milvus/MySQL/Redis/LLM), so CI is green without provisioning those.
- No ruff is configured in the project, so no lint step was added (kept honest, not faked).

## Verification
Ran the exact CI commands locally in a fresh clone: `uv sync --frozen --python 3.11` (exit 0) and `uv run --frozen --python 3.11 pytest` -> 37 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)